### PR TITLE
Add name suffix variable as output

### DIFF
--- a/modules/linux-web-app/outputs.tf
+++ b/modules/linux-web-app/outputs.tf
@@ -104,3 +104,8 @@ output "application_insights_application_type" {
   description = "Application Type of the Application Insights associated to the App Service"
   value       = try(local.app_insights.application_type, null)
 }
+
+output "name_suffix" {
+  description = "name suffix of the app service"
+  value = var.name_suffix
+}

--- a/modules/windows-web-app/outputs.tf
+++ b/modules/windows-web-app/outputs.tf
@@ -104,3 +104,8 @@ output "application_insights_application_type" {
   description = "Application Type of the Application Insights associated to the App Service"
   value       = try(local.app_insights.application_type, null)
 }
+
+output "name_suffix" {
+  description = "name suffix of the app service"
+  value = var.name_suffix
+}

--- a/outputs-web-app.tf
+++ b/outputs-web-app.tf
@@ -12,3 +12,8 @@ output "app_service_windows" {
   description = "App Service Windows (Windows WebApp) output object if Windows is choosen. Please refer to `./modules/windows-web-app/README.md`"
   value       = try(module.windows_web_app["enabled"], null)
 }
+
+output "name_suffix" {
+  description = "Suffix to append to the App Service name"
+  value       = var.name_suffix
+}


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Since this variable is static, it can be useful when using module keys in a for_each, e.g.

resource "azurerm_role_assignment" "workload_identity_kv_secrets_user" {
  for_each = {
    for app in [module.api_app, module.admin_app] : app.name_suffix => app.app_service_windows.app_service_identity_service_principal_id
  }
  scope                = module.key_vault.key_vault.id
  principal_id         = each.value
  principal_type       = "ServicePrincipal"
  role_definition_name = "Key Vault Secrets User"
}
```