### PR TITLE
ignore changes to private_dns_zone_group in private endpoint resources

### DIFF
--- a/modules/container-web-app/r-private-endpoints.tf
+++ b/modules/container-web-app/r-private-endpoints.tf
@@ -14,7 +14,10 @@ resource "azurerm_private_endpoint" "main_pe" {
 
   lifecycle {
     # Avoid recreation of the private endpoint due to moving to central module
-    ignore_changes = [private_service_connection[0].name]
+    ignore_changes = [
+      private_service_connection[0].name,
+      private_dns_zone_group,
+    ]
   }
 }
 

--- a/modules/linux-web-app/r-private-endpoints.tf
+++ b/modules/linux-web-app/r-private-endpoints.tf
@@ -14,7 +14,10 @@ resource "azurerm_private_endpoint" "main_pe" {
 
   lifecycle {
     # Avoid recreation of the private endpoint due to moving to central module
-    ignore_changes = [private_service_connection[0].name]
+    ignore_changes = [
+      private_service_connection[0].name,
+      private_dns_zone_group,
+    ]
   }
 }
 

--- a/modules/windows-web-app/r-private-endpoints.tf
+++ b/modules/windows-web-app/r-private-endpoints.tf
@@ -14,7 +14,10 @@ resource "azurerm_private_endpoint" "main_pe" {
 
   lifecycle {
     # Avoid recreation of the private endpoint due to moving to central module
-    ignore_changes = [private_service_connection[0].name]
+    ignore_changes = [
+      private_service_connection[0].name,
+      private_dns_zone_group,
+    ]
   }
 }
 

--- a/outputs-service-plan.tf
+++ b/outputs-service-plan.tf
@@ -2,3 +2,4 @@ output "service_plan" {
   description = "Service Plan output object. Please refer to https://github.com/claranet/terraform-azurerm-app-service-plan/blob/master/README.md#outputs"
   value       = module.service_plan
 }
+


### PR DESCRIPTION
Terraform need to ignore changes to this value to support policy that creates dns zone groups for private endpoints

## Changelog entry
```
ignore changes to private_dns_zone_group in private endpoint resources
```