### PR TITLE
Configure App Service TLS cipher suite

### DIFF
--- a/modules-web-app.tf
+++ b/modules-web-app.tf
@@ -12,7 +12,7 @@ module "network_vars" {
   count  = local.public_network_access_enabled == true ? 1 : 0
   source = "git@github.com:miljodir/cp-shared.git//modules/public_nw_ips?ref=public_nw_ips/v1"
 }
-
+  
 module "linux_web_app" {
   for_each = toset(lower(var.os_type) == "linux" ? ["enabled"] : [])
 

--- a/modules/container-web-app/r-appservice.tf
+++ b/modules/container-web-app/r-appservice.tf
@@ -27,6 +27,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       local_mysql_enabled               = lookup(site_config.value, "local_mysql_enabled", false)
       managed_pipeline_mode             = lookup(site_config.value, "managed_pipeline_mode", null)
       minimum_tls_version               = lookup(site_config.value, "min_tls_version", "1.3")
+      minimum_tls_cipher_suite          = startswith(var.resource_group_name, "p-") ? null : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
       remote_debugging_enabled          = lookup(site_config.value, "remote_debugging_enabled", false)
       remote_debugging_version          = lookup(site_config.value, "remote_debugging_version", null)
       use_32_bit_worker                 = lookup(site_config.value, "use_32_bit_worker", false)

--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -26,6 +26,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       local_mysql_enabled               = lookup(site_config.value, "local_mysql_enabled", false)
       managed_pipeline_mode             = lookup(site_config.value, "managed_pipeline_mode", null)
       minimum_tls_version               = lookup(site_config.value, "min_tls_version", "1.3")
+      minimum_tls_cipher_suite          = startswith(var.resource_group_name, "p-") ? null : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
       remote_debugging_enabled          = lookup(site_config.value, "remote_debugging_enabled", false)
       remote_debugging_version          = lookup(site_config.value, "remote_debugging_version", null)
       use_32_bit_worker                 = lookup(site_config.value, "use_32_bit_worker", false)

--- a/modules/windows-web-app/r-appservice.tf
+++ b/modules/windows-web-app/r-appservice.tf
@@ -25,6 +25,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       local_mysql_enabled               = lookup(site_config.value, "local_mysql_enabled", false)
       managed_pipeline_mode             = lookup(site_config.value, "managed_pipeline_mode", null)
       minimum_tls_version               = lookup(site_config.value, "min_tls_version", "1.3")
+      minimum_tls_cipher_suite          = startswith(var.resource_group_name, "p-") ? null : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
       remote_debugging_enabled          = lookup(site_config.value, "remote_debugging_enabled", false)
       remote_debugging_version          = lookup(site_config.value, "remote_debugging_version", null)
       use_32_bit_worker                 = lookup(site_config.value, "use_32_bit_worker", false)


### PR DESCRIPTION
## Changelog entry
```
- Configure the minimum TLS cipher suite for Linux and Windows Function Apps and their slots.
- Leave the cipher suite unset for resource groups beginning with p-.
```